### PR TITLE
Set planner read-only mode based on user role

### DIFF
--- a/app/(protected)/giornaliera/daily-planner.tsx
+++ b/app/(protected)/giornaliera/daily-planner.tsx
@@ -36,6 +36,7 @@ import { PlusCircle } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
 import Link from "next/link";
 import AthleteSelectSwitcher from "@/components/athlete-select-switcher";
+import { useRole } from "@/lib/hooks/use-role";
 
 interface DailyPlannerProps {
   athletes: Athlete[];
@@ -173,7 +174,8 @@ export default function DailyPlanner({ athletes }: DailyPlannerProps) {
     return map;
   }, [trainings]);
 
-  const isReadOnly = athletes.length === 1;
+  const { role } = useRole();
+  const isReadOnly = role === "athlete";
   const today = startOfToday();
 
   return (

--- a/app/(protected)/settimanale/weekly-planner.tsx
+++ b/app/(protected)/settimanale/weekly-planner.tsx
@@ -26,6 +26,7 @@ import {
 import WeeklyGoalForm from "./weekly-goal-form";
 import { type Athlete } from "@/lib/actions/athletes";
 import AthleteSelectSwitcher from "@/components/athlete-select-switcher";
+import { useRole } from "@/lib/hooks/use-role";
 
 type Competition = {
   id: string;
@@ -62,7 +63,8 @@ export default function WeeklyPlanner({
   const weeksInYear = getWeeksInYear(year);
   const weeks = Array.from({ length: weeksInYear }, (_, i) => i + 1);
 
-  const isReadOnly = athletes.length === 1;
+  const { role } = useRole();
+  const isReadOnly = role === "athlete";
   const currentWeek = (() => {
     const today = new Date();
     if (year !== today.getFullYear()) return null;


### PR DESCRIPTION
Updated both daily and weekly planner components to determine read-only mode using the user's role instead of the number of athletes. The planners are now read-only when the user role is 'athlete', improving access control logic.